### PR TITLE
Multi project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ config.rails_lineman.lineman_project_location = {
 }
 ```
 
-A hash configuration will result in your lineman assets being namespaced under "lineman/<app-name>", as opposed to at the root "lineman/" like they usually are.
+A hash configuration will result in your lineman assets being namespaced under "lineman/<app-name>", as opposed to at the root "lineman/" like they usually are. Keep this in mind when referencing your assets (e.g. you would need in this example to reference the second app's CSS as `<%= stylesheet_link_tag "lineman/admin-ui/app" %>`)
 
 ## Specifying asset types
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ config.rails_lineman.lineman_project_location = {
 }
 ```
 
+A hash configuration will result in your lineman assets being namespaced under "lineman/<app-name>", as opposed to at the root "lineman/" like they usually are.
+
 ## Specifying asset types
 
 By default, rails-lineman will only copy `dist/js` and `dist/css` from your Lineman

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ config.rails_lineman.lineman_project_location = "some-directory"
 
 You can also set an environment variable named `LINEMAN_PROJECT_LOCATION`
 
+### Pointing at multiple lineman projects
+
+If you want to include multiple lineman projects, then you can provide a hash of logical names mapping to their path location.
+
+```
+config.rails_lineman.lineman_project_location = {
+  "my-app" => "app1",
+  "admin-ui" => "app2"
+}
+```
+
+The `LINEMAN_PROJECT_LOCATION` env variable will be ignored in this case, but you can of course bring your own like so:
+
+```
+config.rails_lineman.lineman_project_location = {
+  "my-app" => ENV['APP1_PATH'],
+  "admin-ui" => ENV['APP2_PATH']
+}
+```
+
 ## Specifying asset types
 
 By default, rails-lineman will only copy `dist/js` and `dist/css` from your Lineman

--- a/lib/rails_lineman/asset.rb
+++ b/lib/rails_lineman/asset.rb
@@ -25,14 +25,12 @@ module RailsLineman
     end
 
     def add_if_precompilable
-      if(is_precompilable?)
-        Rails.application.config.assets.precompile +=
-          Dir.glob("#{@destination}/**/*.#{@descriptor}")
-      end
+      return unless is_precompilable?
+      Rails.application.config.assets.precompile += Dir.glob("#{@destination}/**/*.#{@descriptor}")
     end
 
     def is_precompilable?
-      ["js", "css"].member? @descriptor
+      ["js", "css"].include?(@descriptor)
     end
 
     def delete

--- a/lib/rails_lineman/asset.rb
+++ b/lib/rails_lineman/asset.rb
@@ -3,15 +3,7 @@ module RailsLineman
     def initialize(config, descriptor)
       @descriptor = descriptor.strip
       @source = File.join(config.lineman_project_location, "dist", descriptor, ".")
-      @destination = destination
-    end
-
-    def destination
-      if is_precompilable?
-        Rails.root.join(File.join("tmp", "rails_lineman", "lineman"))
-      else
-        Rails.root.join(File.join("public", "assets", @descriptor))
-      end
+      @destination = determine_destination(config.lineman_project_namespace)
     end
 
     def ensure_directories
@@ -20,21 +12,31 @@ module RailsLineman
       end
     end
 
-    def copy
-      FileUtils.cp_r(@source, @destination)
-    end
-
     def add_if_precompilable
       return unless is_precompilable?
       Rails.application.config.assets.precompile += Dir.glob("#{@destination}/**/*.#{@descriptor}")
     end
 
-    def is_precompilable?
-      ["js", "css"].include?(@descriptor)
+    def copy
+      FileUtils.cp_r(@source, @destination)
     end
 
     def delete
       FileUtils.rm_rf(@destination)
+    end
+
+  private
+
+    def determine_destination(namespace)
+      if is_precompilable?
+        Rails.root.join(File.join(*["tmp", "rails_lineman", "lineman", namespace].compact))
+      else
+        Rails.root.join(File.join(*["public", "assets", namespace, @descriptor].compact))
+      end
+    end
+
+    def is_precompilable?
+      ["js", "css"].include?(@descriptor)
     end
   end
 end

--- a/lib/rails_lineman/lineman_doer.rb
+++ b/lib/rails_lineman/lineman_doer.rb
@@ -65,18 +65,17 @@ module RailsLineman
     end
 
     def install_node_js_on_heroku
-      if heroku?
-        puts "It looks like we're on heroku, so let's install Node.js"
-        system <<-BASH
-          node_version=$(curl --silent --get https://semver.io/node/resolve)
-          node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
-          curl "$node_url" -s -o - | tar xzf - -C .
-          mv node-v$node_version-linux-x64 heroku_node_install
-          chmod +x heroku_node_install/bin/*
-          export PATH="$PATH:$(pwd)/heroku_node_install/bin"
-        BASH
-        ENV['PATH'] += ":#{Dir.pwd}/heroku_node_install/bin"
-      end
+      return unless heroku? && !ENV['PATH'].include?("#{Dir.pwd}/heroku_node_install/bin")
+      puts "It looks like we're on heroku, so let's install Node.js"
+      system <<-BASH
+        node_version=$(curl --silent --get https://semver.io/node/resolve)
+        node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
+        curl "$node_url" -s -o - | tar xzf - -C .
+        mv node-v$node_version-linux-x64 heroku_node_install
+        chmod +x heroku_node_install/bin/*
+        export PATH="$PATH:$(pwd)/heroku_node_install/bin"
+      BASH
+      ENV['PATH'] += ":#{Dir.pwd}/heroku_node_install/bin"
     end
 
     def heroku?

--- a/lib/rails_lineman/meta_lineman_doer.rb
+++ b/lib/rails_lineman/meta_lineman_doer.rb
@@ -1,0 +1,29 @@
+require 'rails_lineman/lineman_doer'
+
+module RailsLineman
+  class MetaLinemanDoer
+    def initialize(config)
+      @lineman_doers = options_per_project(config).map {|c| LinemanDoer.new(c) }
+    end
+
+    def precompile_assets
+      @lineman_doers.map(&:precompile_assets)
+    end
+
+    def destroy_assets
+      @lineman_doers.map(&:destroy_assets)
+    end
+
+    private
+
+    def options_per_project(config)
+      return [config] unless config.lineman_project_location.respond_to?(:keys)
+      config.lineman_project_location.map do |(name, location)|
+        config.dup.tap do |single_project_config|
+          single_project_config.lineman_project_location = location
+          single_project_config.lineman_project_namespace = name.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_lineman/railtie.rb
+++ b/lib/rails_lineman/railtie.rb
@@ -13,7 +13,7 @@ module RailsLineman
       load(File.join(File.dirname(__FILE__), '..', 'tasks', 'assets_precompile.rake'))
     end
 
-    initializer "rails_jasmine.add_asset_paths" do
+    initializer "rails_lineman.add_asset_paths" do
       Rails.application.config.assets.paths |= config.rails_lineman.asset_paths.map { |path| Rails.root.join(path) }
     end
   end

--- a/lib/rails_lineman/railtie.rb
+++ b/lib/rails_lineman/railtie.rb
@@ -3,6 +3,7 @@ module RailsLineman
     config.rails_lineman = ActiveSupport::OrderedOptions.new
 
     config.rails_lineman.lineman_project_location = ENV['LINEMAN_PROJECT_LOCATION']
+    config.rails_lineman.lineman_project_namespace = nil
     config.rails_lineman.lineman_assets = ENV['LINEMAN_ASSETS'] || [:js, :css]
     config.rails_lineman.remove_lineman_assets_after_asset_pipeline_precompilation = false
     config.rails_lineman.skip_build = false

--- a/lib/tasks/assets_precompile.rake
+++ b/lib/tasks/assets_precompile.rake
@@ -10,7 +10,7 @@ namespace :assets do
       lineman_doer.precompile_assets
       Rake::Task["assets:precompile:original"].execute
     ensure
-      lineman_doer.destroy_assets
+      lineman_doer.try(:destroy_assets)
     end
   end
 end

--- a/lib/tasks/assets_precompile.rake
+++ b/lib/tasks/assets_precompile.rake
@@ -1,6 +1,6 @@
 require 'rails_lineman/task_helpers'
 
-require 'rails_lineman/lineman_doer'
+require 'rails_lineman/meta_lineman_doer'
 
 namespace :assets do
   desc 'Compile all the assets named in config.assets.precompile (Wrapped by rails-lineman)'

--- a/lib/tasks/assets_precompile.rake
+++ b/lib/tasks/assets_precompile.rake
@@ -6,8 +6,14 @@ namespace :assets do
   desc 'Compile all the assets named in config.assets.precompile (Wrapped by rails-lineman)'
   RailsLineman::TaskHelpers.override_task :precompile => :environment do
     begin
-      lineman_doer = RailsLineman::LinemanDoer.new(Rails.application.config.rails_lineman)
-      lineman_doer.precompile_assets
+      config = Rails.application.config.rails_lineman
+      if config.lineman_project_location.present?
+        lineman_doer = RailsLineman::MetaLinemanDoer.new(config)
+        lineman_doer.precompile_assets
+      else
+        puts "WARNING: No Lineman project location was set (see: `config.rails_lineman.lineman_project_location`). Skipping Lineman build"
+      end
+
       Rake::Task["assets:precompile:original"].execute
     ensure
       lineman_doer.try(:destroy_assets)


### PR DESCRIPTION
Adds support for building multiple projects while improving error handling when configuration isn't set up at all. Documented in the README.
